### PR TITLE
Move getting git version into native build

### DIFF
--- a/.github/workflows/znn_builder.yml
+++ b/.github/workflows/znn_builder.yml
@@ -36,8 +36,6 @@ jobs:
       #   run: |
       #     go install golang.org/x/vuln/cmd/govulncheck@latest
       #     /home/runner/go/bin/govulncheck -json ./...
-      - name: Make version
-        run: make version
       - name: Build znnd
         uses: crazy-max/ghaction-xgo@588a1a9bc6aa44305ce5d2c669c11687316f87bf
         with:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all clean znnd version
+.PHONY: all clean znnd
 
 GO ?= latest
 
@@ -18,8 +18,8 @@ ifeq ($(detected_OS),Linux)
     EXECUTABLE=libznn.so
 endif
 
-SERVERMAIN = $(shell pwd)/cmd/znnd/main.go
-LIBMAIN = $(shell pwd)/cmd/libznn/main_libznn.go
+SERVERMAIN = $(shell pwd)/cmd/znnd
+LIBMAIN = $(shell pwd)/cmd/libznn
 BUILDDIR = $(shell pwd)/build
 GIT_COMMIT=$(shell git rev-parse HEAD)
 GIT_COMMIT_FILE=$(shell pwd)/metadata/git_commit.go
@@ -34,12 +34,6 @@ znnd:
 	go build -o $(BUILDDIR)/znnd $(SERVERMAIN)
 	@echo "Build znnd done."
 	@echo "Run \"$(BUILDDIR)/znnd\" to start znnd."
-
-version:
-	@echo "package metadata\n" > $(GIT_COMMIT_FILE)
-	@echo "const (" >> $(GIT_COMMIT_FILE)
-	@echo "\tGitCommit = \"${GIT_COMMIT}\"" >> $(GIT_COMMIT_FILE)
-	@echo ")" >> $(GIT_COMMIT_FILE)
 
 clean:
 	rm -r $(BUILDDIR)/

--- a/metadata/git_commit.go
+++ b/metadata/git_commit.go
@@ -1,5 +1,14 @@
 package metadata
 
-const (
-	GitCommit = "7e9c440f7e5e368efbade77ca900efa1219af0d4"
-)
+import "runtime/debug"
+
+var GitCommit = func() string {
+	if info, ok := debug.ReadBuildInfo(); ok {
+		for _, setting := range info.Settings {
+			if setting.Key == "vcs.revision" {
+				return setting.Value
+			}
+		}
+	}
+	return ""
+}()


### PR DESCRIPTION
https://stackoverflow.com/questions/71642366/how-do-you-read-debug-vcs-version-info-from-a-go-1-18-binary

Notably, that go commands are meant to run on package not file argument